### PR TITLE
fix: export contract types (`api-types.ts`) 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@
 export { default as mainMw } from './main-mw.ts';
 export { load as init } from './server-settings.ts';
 
-/** db-types and src/types are internal to this project */
+// db-types.ts registers its types globally and is not explicitly
+// imported by other files. This ensures that Typescript doesn't miss these.
 import './db-types.ts';
 
 /** contract types */


### PR DESCRIPTION
😬 Woops, was still unable to import types as they were not exported from `src/index.ts`  🐸 
Also added comments to clarify internal types for project