### PR TITLE
fix(oauth2): require secret when refreshing tokens

### DIFF
--- a/src/oauth2/controller/token.ts
+++ b/src/oauth2/controller/token.ts
@@ -54,7 +54,7 @@ class TokenController extends Controller {
       case 'password' :
         return this.password(oauth2Client, ctx);
       case 'refresh_token' :
-        return this.refreshToken(oauth2Client, ctx);
+        return this.refreshToken(oauth2Client, ctx, secretUsed);
     }
 
   }
@@ -172,7 +172,7 @@ class TokenController extends Controller {
 
   }
 
-  async refreshToken(oauth2Client: AppClient, ctx: Context<any>) {
+  async refreshToken(oauth2Client: AppClient, ctx: Context<any>, secretUsed: boolean) {
 
     if (!ctx.request.body.refresh_token) {
       throw new InvalidRequest('The "refresh_token" property is required');
@@ -180,7 +180,8 @@ class TokenController extends Controller {
 
     const token = await oauth2Service.generateTokenFromRefreshToken(
       oauth2Client,
-      ctx.request.body.refresh_token
+      ctx.request.body.refresh_token,
+      secretUsed
     );
 
     ctx.response.type = 'application/json';

--- a/src/oauth2/service.ts
+++ b/src/oauth2/service.ts
@@ -388,7 +388,11 @@ export function validatePKCE(codeVerifier: string|undefined, codeChallenge: stri
  * By specifying a refresh token, a new access/refresh token pair gets
  * returned. This also expires the old token.
  */
-export async function generateTokenFromRefreshToken(client: AppClient, refreshToken: string): Promise<OAuth2Token> {
+export async function generateTokenFromRefreshToken(
+  client: AppClient,
+  refreshToken: string,
+  secretUsedNow: boolean
+): Promise<OAuth2Token> {
 
   let oldToken: OAuth2Token;
   try {
@@ -405,6 +409,8 @@ export async function generateTokenFromRefreshToken(client: AppClient, refreshTo
     throw new UnauthorizedClient('The client_id associated with the refresh did not match with the authenticated client credentials');
   }
 
+  ensureRefreshSecretRequirement(oldToken.secretUsed, secretUsedNow);
+
   await revokeToken(oldToken);
 
   return generateTokenInternal({
@@ -415,6 +421,12 @@ export async function generateTokenFromRefreshToken(client: AppClient, refreshTo
     secretUsed: oldToken.secretUsed,
   });
 
+}
+
+export function ensureRefreshSecretRequirement(originalSecretUsed: boolean, secretUsedNow: boolean): void {
+  if (originalSecretUsed && !secretUsedNow) {
+    throw new InvalidGrant('Client authentication is required to refresh this token');
+  }
 }
 
 export async function revokeByAccessRefreshToken(client: AppClient, token: string): Promise<void> {

--- a/test/oauth2/refresh-secret-requirement.ts
+++ b/test/oauth2/refresh-secret-requirement.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { ensureRefreshSecretRequirement } from '../../src/oauth2/service.js';
+
+describe('ensureRefreshSecretRequirement', () => {
+  it('throws when original token used a secret and refresh does not authenticate', () => {
+    assert.throws(
+      () => ensureRefreshSecretRequirement(true, false),
+      /client authentication/i
+    );
+  });
+
+  it('allows refresh when both original and current requests use a secret', () => {
+    assert.doesNotThrow(() => ensureRefreshSecretRequirement(true, true));
+  });
+
+  it('allows refresh when original token did not use a secret', () => {
+    assert.doesNotThrow(() => ensureRefreshSecretRequirement(false, false));
+  });
+});


### PR DESCRIPTION
## Summary\n- require confidential refreshes to authenticate with the original client secret\n- plumb the `secretUsed` flag from the controller to the refresh service\n- cover the secret parity guard with a focused node:test suite\n\n## Testing\n- npx tsx --test test/oauth2/refresh-secret-requirement.ts\n\nFixes curveball/a12n-server#18.